### PR TITLE
Fix: CRC-16 checksum incorrect for non-ASCII characters

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: Test
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm test --run --reporter=verbose --reporter=github-actions

--- a/package.json
+++ b/package.json
@@ -25,19 +25,19 @@
   "browser": "dist/index.global.js",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     },
     "./generate": {
+      "types": "./dist/generate/index.d.ts",
       "import": "./dist/generate/index.mjs",
-      "require": "./dist/generate/index.js",
-      "types": "./dist/generate/index.d.ts"
+      "require": "./dist/generate/index.js"
     },
     "./validate": {
+      "types": "./dist/validate/index.d.ts",
       "import": "./dist/validate/index.mjs",
-      "require": "./dist/validate/index.js",
-      "types": "./dist/validate/index.d.ts"
+      "require": "./dist/validate/index.js"
     }
   },
   "files": [

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -32,6 +32,22 @@ test('Parse payload (strict) with valid checksum and get tag value', () => {
   ).toBe('0066801111111')
 })
 
+test('Parse payload (strict) which contain non-ascii characters with valid checksum and make valid crc', () => {
+  expect(
+    parse(
+      '00020101021251400116A0000006770101120206001234030600123452041234530376454035005802TH5907ร้านค้า6007Bangkok6304599E',
+      true,
+    )?.getTagValue('59'),
+  ).toBe('ร้านค้า')
+
+  expect(
+    parse(
+      '00020101021251400116A0000006770101120206001234030600123452041234530376454035005802CN5902商人6007Beijing63042B8C',
+      true,
+    )?.getTagValue('59'),
+  ).toBe('商人')
+})
+
 test('Generate Any ID', () => {
   expect(
     generate.anyId({
@@ -177,9 +193,7 @@ test('Convert BOT Barcode to Bill Payment (Invalid, data loss)', () => {
 
 test('Validate AnyID (MSISDN, no amount)', () => {
   expect(
-    validate.anyId(
-      generate.anyId({ type: 'MSISDN', target: '0812223333' }),
-    ),
+    validate.anyId(generate.anyId({ type: 'MSISDN', target: '0812223333' })),
   ).toEqual({ type: 'MSISDN', target: '0812223333' })
 })
 
@@ -193,9 +207,7 @@ test('Validate AnyID (MSISDN, with amount)', () => {
 
 test('Validate AnyID (NATID)', () => {
   expect(
-    validate.anyId(
-      generate.anyId({ type: 'NATID', target: '1234567890123' }),
-    ),
+    validate.anyId(generate.anyId({ type: 'NATID', target: '1234567890123' })),
   ).toEqual({ type: 'NATID', target: '1234567890123' })
 })
 

--- a/src/utils/checksum.ts
+++ b/src/utils/checksum.ts
@@ -34,9 +34,9 @@ const TABLE = [
 ]
 
 export function crc16xmodem(data: string, crc = 0x0) {
-  for (const i of data) {
-    const b = i.charCodeAt(0)
-    const n = (b ^ (crc >> 8)) & 0xff
+  const bytes = new TextEncoder().encode(data)
+  for (let i = 0; i < bytes.length; i++) {
+    const n = (bytes[i] ^ (crc >> 8)) & 0xff
     crc = TABLE[n] ^ (crc << 8)
   }
   return (crc ^ 0) & 0xffff

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": ["ESNext"],
+    "lib": [ "ESNext", "DOM" ],
     "module": "ESNext",
     "moduleResolution": "bundler",
 
@@ -15,8 +15,8 @@
     "forceConsistentCasingInFileNames": true,
 
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [ "./src/*" ]
     }
   },
-  "include": ["./src"]
+  "include": [ "./src" ]
 }


### PR DESCRIPTION
## Issue
From Issue 
- #7 

## Fix
Fixes #7 

Replace charCodeAt(0) with new TextEncoder().encode(data), which yields the actual UTF-8 byte sequence the EMVCo spec calls for. TextEncoder is a Web API available natively in Node.js 11+, all modern  
 browsers, Deno, and Bun — no polyfill needed.

tsconfig.json gains "DOM" in lib so TypeScript resolves the TextEncoder type.

## Test

Added a test case that parses a PromptPay payload containing non-ascii characters in the merchant name field (tag 59) in strict mode (checksum validation on). The test was failing before this fix.

---